### PR TITLE
Fix async settings bug

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,6 @@
     "47",
     "48"
   ],
-  "version": 3,
+  "version": 4,
   "url": "https://github.com/ScottGarman/music-scales-gnome-extension"
 }


### PR DESCRIPTION
Since switching to async loading of settings, we had a race condition which could result in the following error after extensions are reloaded:

TypeError: scaleNotes is undefined

Use a promise that resolves when loading settings is complete (or immediately if there is no settings file). And as an added safeguard, check that our scale data exists at the start of _updateKeyboard, and fall back to defaults if there are any issues.